### PR TITLE
collapse MPC functions so we can put them in the paper

### DIFF
--- a/examples/GMWReal.hs
+++ b/examples/GMWReal.hs
@@ -16,7 +16,6 @@ import Data (TestArgs, reference)
 import Data.Kind (Type)
 import Data.Maybe (fromJust)
 import GHC.TypeLits (KnownSymbol)
-import Logic.Classes (refl)
 import System.Random
 import Test.QuickCheck (Arbitrary, arbitrary, chooseInt, elements, getSize, oneof, resize)
 
@@ -49,7 +48,7 @@ instance Show (Circuit ps) where
 instance Arbitrary (Circuit '["p1", "p2", "p3", "p4"]) where
   arbitrary = do size <- getSize
                  if 1 >= size
-                   then oneof $ (LitWire <$> arbitrary) : (return <$> [InputWire p1, InputWire p2, InputWire p3, InputWire p4])
+                   then oneof $ (LitWire <$> arbitrary) : (pure <$> [InputWire p1, InputWire p2, InputWire p3, InputWire p4])
                    else do left <- chooseInt (1, size)
                            a <- resize left arbitrary
                            b <- resize (1 `max` (size - left)) arbitrary
@@ -76,81 +75,45 @@ instance TestArgs Args (Bool, Bool, Bool, Bool) where
 
 
 genShares :: (MonadIO m) => [LocTm] -> Bool -> m [(LocTm, Bool)]
-genShares parties x = do
-  freeShares <- replicateM (length parties - 1) $ liftIO randomIO -- generate n-1 random shares
-  return $ zip parties $ xor (x : freeShares) : freeShares        -- make the sum equal to x
+genShares partyNames x = do
+  freeShares <- replicateM (length partyNames - 1) $ liftIO randomIO -- generate n-1 random shares
+  return $ zip partyNames $ xor (x : freeShares) : freeShares        -- make the sum equal to x
 
 secretShare :: forall parties p m. (KnownSymbols parties, KnownSymbol p, MonadIO m)
             => Member p parties -> Located '[p] Bool -> Choreo parties m (Faceted parties Bool)
 secretShare p value = do
-  shares <- p `locally` \un -> genShares partyNames (un singleton value)
-  refl `fanOut` \q ->
+  shares <- p `locally` \un -> genShares (toLocs $ allOf @parties) (un singleton value)
+  allOf @parties `fanOut` \q ->
     (p, \un -> return $ fromJust $ toLocTm q `lookup` un singleton shares) ~~> q @@ nobody
-  where partyNames = toLocs @parties refl
 
-reveal :: (KnownSymbols ps)
-       => Faceted ps Bool
-       -> Choreo ps m Bool
-reveal shares = do
-  allShares <- fanIn refl refl \p -> (p, (p, shares)) ~> refl
-  value <- refl `congruently` \un -> case un refl allShares of [] -> error "There's nobody who can hit this"
-                                                               aS -> xor aS
-  naked refl value
+reveal :: forall ps m. (KnownSymbols ps) => Faceted ps Bool -> Choreo ps m Bool
+reveal shares = let ps = allOf @ps
+                in xor <$> ((fanIn ps ps \p -> (p, (p, shares)) ~> ps) >>= naked ps)
 
-genBools :: (MonadIO m) => [LocTm] -> CLI m [(LocTm, Bool)]
-genBools names = mapM genBool names
-  where genBool n = do r <- randomRIO (0, 1 :: Int); return $ (n, r == 0)
 
 -- use OT to do multiplication
 fAnd :: forall parties m. (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
      => Faceted parties Bool -> Faceted parties Bool -> Choreo parties (CLI m) (Faceted parties Bool)
-fAnd u_shares v_shares = do
-  let party_names = toLocs @parties refl
-  a_ij_s  :: Faceted parties [(LocTm, Bool)] <- refl `_parallel` genBools party_names
-  b_ij_s  :: Faceted parties Bool  <- refl `fanOut` (fAndAij a_ij_s u_shares v_shares)
-  names   :: Faceted parties LocTm <- refl `fanOut` \p_i -> p_i `_locally` return (toLocTm p_i)
-  shares' :: Faceted parties Bool  <- refl `parallel` (computeShare names u_shares v_shares a_ij_s b_ij_s)
-  return shares'
-
-fAndAij :: (KnownSymbols parties, KnownSymbol p_j, MonadIO m, CRT.MonadRandom m)
-        => Faceted parties [(LocTm, Bool)] -> Faceted parties Bool -> Faceted parties Bool
-        -> Member p_j parties -> Choreo parties (CLI m) (Located '[p_j] Bool)
-fAndAij a_ij_s u_shares v_shares p_j = do
-  b_jis :: Located '[p_j] [Bool] <- fanIn refl (p_j @@ nobody) (fAndBij a_ij_s u_shares v_shares p_j)
-  b_sum :: Located '[p_j] Bool   <- p_j `locally` \un -> return $ xor $ un singleton b_jis
-  return b_sum
-
-fAndBij :: (KnownSymbols parties, KnownSymbol p_i, KnownSymbol p_j, MonadIO m, CRT.MonadRandom m)
-        => Faceted parties [(LocTm, Bool)] -> Faceted parties Bool -> Faceted parties Bool
-        -> Member p_j parties -> Member p_i parties -> Choreo parties (CLI m) (Located '[p_j] Bool)
-fAndBij a_ij_s u_shares v_shares p_j p_i = do
-  let p_i_name = toLocTm p_i
-      p_j_name = toLocTm p_j
-  case p_i_name == p_j_name of
-    True  -> p_j `_locally` return False
-    False -> do
-      a_ij :: Located '[p_i] Bool <- p_i `locally` \un -> return $ fromJust $ lookup p_j_name (un p_i a_ij_s)
-      u_i  :: Located '[p_i] Bool <- p_i `locally` \un -> return (un p_i u_shares)
-      b1   :: Located '[p_i] Bool <- p_i `locally` \un -> return $ xor [(un singleton u_i), (un singleton a_ij)]
-      b2   :: Located '[p_i] Bool <- p_i `locally` \un -> return $ un singleton a_ij
-      s    :: Located '[p_j] Bool <- p_j `locally` \un -> return (un p_j v_shares)
-      b_ij :: Located '[p_j] Bool <- enclaveTo (p_i @@ p_j @@ nobody) (listedSecond @@ nobody) (ot2 b1 b2 s)
-      return b_ij
-
-computeShare :: (MonadIO m)
-             => Faceted parties LocTm -> Faceted parties Bool -> Faceted parties Bool
-             -> Faceted parties [(LocTm, Bool)] -> Faceted parties Bool -> Member p parties
-             -> Unwrap p -> m Bool
-computeShare ind_names u_shares v_shares a_ij_s b_ij_s p un =
-  return (computeShareL
-           (un p ind_names)
-           (un p u_shares)
-           (un p v_shares)
-           (un p a_ij_s)
-           (un p b_ij_s))
-  where computeShareL name u_i v_i a_ij b = xor $ [u_i && v_i, b] ++ [snd a | a <- a_ij, ok name a]
-        ok partyName (p_j, _) = p_j /= partyName
-
+fAnd uShares vShares = do
+  let partyNames = toLocs (allOf @parties)
+      genBools = mapM (\name -> (name,) <$> randomIO)
+  a_j_s :: Faceted parties [(LocTm, Bool)] <- allOf @parties `_parallel` genBools partyNames
+  bs :: Faceted parties Bool  <- allOf @parties `fanOut` \p_j -> do
+      let p_j_name = toLocTm p_j
+      b_i_s <- fanIn (allOf @parties) (p_j @@ nobody) \p_i ->
+        if toLocTm p_i == p_j_name
+          then p_j `_locally` pure False
+          else do
+              bb <- p_i `locally` \un -> let a_ij = fromJust $ lookup p_j_name (un p_i a_j_s)
+                                             u_i = un p_i uShares
+                                         in pure (xor [u_i, a_ij], a_ij)
+              enclaveTo (p_i @@ p_j @@ nobody) (listedSecond @@ nobody) (ot2 bb $ localize p_j vShares)
+      p_j `locally` \un -> pure $ xor $ un singleton b_i_s
+  allOf @parties `parallel` \p_i un ->
+    let name = toLocTm p_i
+        ok p_j = p_j /= name
+        computeShare u v a_js b = xor $ [u && v, b] ++ [a_j | (p_j, a_j) <- a_js, ok p_j]
+    in pure $ computeShare (un p_i uShares) (un p_i vShares) (un p_i a_j_s) (un p_i bs)
 
 gmw :: forall parties m. (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
     => Circuit parties -> Choreo parties (CLI m) (Faceted parties Bool)
@@ -158,24 +121,23 @@ gmw circuit = case circuit of
   InputWire p -> do        -- process a secret input value from party p
     value :: Located '[p] Bool <- p `_locally` getInput "Enter a secret input value:"
     secretShare p value
-  LitWire b ->             -- process a publicly-known literal value
-    let shares = partyNames `zip` (b : repeat False) in
-    refl `fanOut` \p -> p `_locally` return (fromJust $ toLocTm p `lookup` shares)
+  LitWire b -> do          -- process a publicly-known literal value
+    let partyNames = toLocs (allOf @parties)
+        shares = partyNames `zip` (b : repeat False)
+    allOf @parties `fanOut` \p -> p `_locally` pure (fromJust $ toLocTm p `lookup` shares)
   AndGate l r -> do        -- process an AND gate
     lResult <- gmw l; rResult <- gmw r;
     fAnd lResult rResult
   XorGate l r -> do        -- process an XOR gate
     lResult <- gmw l; rResult <- gmw r
-    refl `parallel` \p un -> return $ xor [un p lResult, un p rResult]
-  where partyNames = toLocs @parties refl
+    allOf @parties `parallel` \p un -> pure $ xor [un p lResult, un p rResult]
 
-mpc :: (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
-    => Circuit parties
-    -> Choreo parties (CLI m) ()
+mpc :: forall parties m. (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
+    => Circuit parties -> Choreo parties (CLI m) ()
 mpc circuit = do
   outputWire <- gmw circuit
   result <- reveal outputWire
-  void $ refl `_parallel` putOutput "The resulting bit:" result
+  void $ allOf @parties `_parallel` putOutput "The resulting bit:" result
 
 mpcmany :: (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
     => Circuit parties


### PR DESCRIPTION
I think we can probably put a reasonably complete GMW implementation in the paper, with OT in the appendix. 
Breaking up secret-share/reveal and the GMW itself into two figures does look good though.
I haven't actually checked how well this fits, but I think **if** it's not over-golfed then it'll fit in the paper.