### PR TITLE
Remove infix

### DIFF
--- a/examples/GMWReal.hs
+++ b/examples/GMWReal.hs
@@ -78,13 +78,13 @@ genShares :: forall ps p m. (MonadIO m, KnownSymbols ps) => Member p ps -> Bool 
 genShares p x = quorum1 p gs'
   where gs' :: forall q qs. (KnownSymbol q, KnownSymbols qs) => m (Quire (q ': qs) Bool)
         gs' = do freeShares <- sequence $ pure $ liftIO randomIO -- generate n-1 random shares
-                 return $ xor (qCons @q x freeShares) `qCons` freeShares
+                 return $ qCons (xor (qCons @q x freeShares)) freeShares
 
 
 secretShare :: forall parties p m. (KnownSymbols parties, KnownSymbol p, MonadIO m)
             => Member p parties -> Located '[p] Bool -> Choreo parties m (Faceted parties '[] Bool)
 secretShare p value = do
-  shares <- p `locally` \un -> genShares p (un singleton value)
+  shares <- locally p \un -> genShares p (un singleton value)
   PIndexed fs <- scatter p (allOf @parties) shares
   return $ PIndexed $ Facet . othersForget (First @@ nobody) . getFacet . fs
 
@@ -101,46 +101,49 @@ fAnd :: forall parties m.
      -> Choreo parties (CLI m) (Faceted parties '[] Bool)
 fAnd uShares vShares = do
   let genBools = sequence $ pure randomIO
-  a_j_s :: Faceted parties '[] (Quire parties Bool) <- allOf @parties `_parallel` genBools
+  a_j_s :: Faceted parties '[] (Quire parties Bool) <- _parallel (allOf @parties) genBools
   bs :: Faceted parties '[] Bool <- fanOut \p_j -> do
       let p_j_name = toLocTm p_j
       b_i_s <- fanIn (p_j @@ nobody) \p_i ->
         if toLocTm p_i == p_j_name
-          then p_j `_locally` pure False
+          then _locally p_j $ pure False
           else do
-              bb <- p_i `locally` \un -> let a_ij = viewFacet un p_i a_j_s `getLeaf` p_j
-                                             u_i = viewFacet un p_i uShares
+              -- bb is the truth table
+              bb <- locally p_i \un -> let a_ij = getLeaf (viewFacet un p_i a_j_s) p_j
+                                           u_i = viewFacet un p_i uShares
                                          in pure (xor [u_i, a_ij], a_ij)
+                                            -- localize p_j vSHares is party j's share of v
               enclaveTo (p_i @@ p_j @@ nobody) (listedSecond @@ nobody) (ot2 bb $ localize p_j vShares)
-      p_j `locally` \un -> pure $ xor $ un singleton b_i_s
-  allOf @parties `parallel` \p_i un ->
+      locally p_j \un -> pure $ xor $ un singleton b_i_s
+  parallel (allOf @parties) \p_i un ->
     let computeShare u v a_js b = xor $ [u && v, b] ++ toList (qModify p_i (const False) a_js)
-    in pure $ computeShare (viewFacet un p_i uShares) (viewFacet un p_i vShares) (viewFacet un p_i a_j_s) (viewFacet un p_i bs)
+    in pure $ computeShare (viewFacet un p_i uShares) (viewFacet un p_i vShares)
+                           (viewFacet un p_i a_j_s)   (viewFacet un p_i bs)
 
 gmw :: forall parties m. (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
     => Circuit parties -> Choreo parties (CLI m) (Faceted parties '[] Bool)
 gmw circuit = case circuit of
   InputWire p -> do        -- process a secret input value from party p
-    value :: Located '[p] Bool <- p `_locally` getInput "Enter a secret input value:"
+    value :: Located '[p] Bool <- _locally p $ getInput "Enter a secret input value:"
     secretShare p value
   LitWire b -> do          -- process a publicly-known literal value
     let chooseShare :: forall p. (KnownSymbol p) => Member p parties -> Choreo parties (CLI m) (Located '[p] Bool)
-        chooseShare p = (p @@ nobody `congruently` \_ -> case p of First -> b
-                                                                   Later _ -> False)
+        chooseShare p = congruently (p @@ nobody) $ \_ -> case p of First   -> b
+                                                                    Later _ -> False
     fanOut chooseShare
   AndGate l r -> do        -- process an AND gate
     lResult <- gmw l; rResult <- gmw r;
     fAnd lResult rResult
   XorGate l r -> do        -- process an XOR gate
     lResult <- gmw l; rResult <- gmw r
-    allOf @parties `parallel` \p un -> pure $ xor [viewFacet un p lResult, viewFacet un p rResult]
+    parallel (allOf @parties) \p un -> pure $ xor [viewFacet un p lResult, viewFacet un p rResult]
 
 mpc :: forall parties m. (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
     => Circuit parties -> Choreo parties (CLI m) ()
 mpc circuit = do
   outputWire <- gmw circuit
   result <- reveal outputWire
-  void $ allOf @parties `_parallel` putOutput "The resulting bit:" result
+  void $ _parallel (allOf @parties ) $ putOutput "The resulting bit:" result
 
 mpcmany :: (KnownSymbols parties, MonadIO m, CRT.MonadRandom m)
     => Circuit parties

--- a/examples/ObliviousTransfer.hs
+++ b/examples/ObliviousTransfer.hs
@@ -96,12 +96,12 @@ ot2 bb s = do
   let sender = listedFirst :: Member sender '[sender, receiver]
   let receiver = listedSecond :: Member receiver '[sender, receiver]
 
-  keys <- receiver `locally` \un -> liftIO $ genKeys $ un singleton s
+  keys <- locally receiver  \un -> liftIO $ genKeys $ un singleton s
   pks <- (receiver, \un -> let (pk1, pk2, _) = un singleton keys
                            in return (pk1, pk2)) ~~> sender @@ nobody
   encrypted <- (sender, \un -> let (b1, b2) = un singleton bb
                                in liftIO $ encryptS (un singleton pks) b1 b2) ~~> receiver @@ nobody
-  receiver `locally` \un -> liftIO $ decryptS (un singleton keys)
+  locally receiver  \un -> liftIO $ decryptS (un singleton keys)
                                                            (un singleton s)
                                                            (un singleton encrypted)
 


### PR DESCRIPTION
Remove infix notation from the GMW example used in the paper. We don't necessarily need this but I personally prefer keeping my code in sync.